### PR TITLE
Fix R9 value on silkscreen

### DIFF
--- a/bkm-129x-scart-vga.kicad_pcb
+++ b/bkm-129x-scart-vga.kicad_pcb
@@ -2989,7 +2989,7 @@
   (gr_text "C7,8,13 -\n100uF/16V\n6,3x5,3mm\nElectrolytical\n\nC10 - 2.2uF\nC11 - 1.0uF\nRest - 0.1uF\n25V / 0805\n" (at 112.5906 39.64) (layer F.SilkS)
     (effects (font (size 1.3 1.3) (thickness 0.25)) (justify left))
   )
-  (gr_text "R1,3,14,18 - 10K\nR4 - 470R\nR6,7,8,9 - 150R\nR32,33,34 - 150R\nR10,11,12,13 - 75R\nR19,23 - 4K7\nR20,22,25,27 - 100K\nR2,21,24,26,28 - 100R\nR5,15,16 - 1K\nAll 0805 size / 1%" (at 128.8906 40.74) (layer F.SilkS)
+  (gr_text "R1,3,14,18 - 10K\nR4 - 470R\nR6,7,8,32,33,34 - 150R\nR9 - 0R (or jumper)\nR10,11,12,13 - 75R\nR19,23 - 4K7\nR20,22,25,27 - 100K\nR2,21,24,26,28 - 100R\nR5,15,16 - 1K\nAll 0805 size / 1%" (at 128.8906 40.74) (layer F.SilkS) (tstamp 6138C43E)
     (effects (font (size 1.3 1.3) (thickness 0.25)) (justify left))
   )
   (gr_text "U1 - ADG1611\nU2 - THS7374\nU3 - Arduino Nano v3\n      (5V/16MHz)\nU4 - 74VHC125\nU5 - MIC3490-5.0\nQ1 - DTC144EKA\nQ2 - MMBT3904\nD1 - YELLOW 0805 LED\nD2 - RED 0805 LED\nU1/2/4: TSSOP14\nSW1/SW2: PBH4UEEN\nJ3: CUI SJ1-353XNG\n(Like SJ1-3533NG)" (at 86.868 45.085) (layer F.SilkS)


### PR DESCRIPTION
Just finishing assembling my full BNC clone and SCART/VGA boards (just waiting on a pair of ADG1611 to complete) and I noticed that R9 on the BNC clone is shown as 0Ω on the silkscreen but on the SCART/VGA version it's still shown as 150Ω but the schematic says 0Ω.

Assuming that's an oversight, here's a small PR that just updates the silkscreen to match the BNC version. I also condensed the two lines of 3x 150Ω resistors into one line for all of them.
